### PR TITLE
feat: make transport configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,29 @@ You can then ask questions like:
 - "show me metrics for campaign `[CAMPAIGN_ID]`"
 - "get all ad groups"
 
+#### For Other MCP Clients (stdio transport)
+
+Some MCP clients require stdio transport instead of streamable-http. Set the `MCP_TRANSPORT` environment variable to `stdio`:
+
+```json
+{
+  "mcpServers": {
+    "google-ads": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/google-marketing-solutions/google_ads_mcp.git",
+        "run-mcp-server"
+      ],
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "GOOGLE_ADS_CREDENTIALS": "PATH_TO_YAML"
+      }
+    }
+  }
+}
+```
+
 #### Direct Launch
 
 To start the server directly, in the project path, run the following command:
@@ -115,6 +138,14 @@ uv run -m ads_mcp.server
 ```
 
 The server will start and be ready to accept requests.
+
+You can specify the transport mode via the `MCP_TRANSPORT` environment variable:
+
+| Transport | Use Case | Example |
+|-----------|----------|---------|
+| `streamable-http` | HTTP-based clients (default) | `uv run -m ads_mcp.server` |
+| `stdio` | CLI-based MCP clients | `MCP_TRANSPORT=stdio uv run -m ads_mcp.server` |
+| `sse` | Server-Sent Events | `MCP_TRANSPORT=sse uv run -m ads_mcp.server` |
 
 ## Contributing
 

--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -48,11 +48,8 @@ def main():
   """Initializes and runs the MCP server."""
   asyncio.run(update_views_yaml())  # Check and update docs resource
   api.get_ads_client()  # Check Google Ads credentials
-  print("mcp server starting...")
-  mcp_server.run(
-      transport="streamable-http",
-      show_banner=False,
-  )  # Initialize and run the server
+  transport = os.getenv("MCP_TRANSPORT", "streamable-http")
+  mcp_server.run(transport=transport, show_banner=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `MCP_TRANSPORT` environment variable to configure the server transport
- Default remains `streamable-http` to maintain backward compatibility
- Enables support for CLI-based MCP clients that require `stdio` transport

## Motivation

The MCP ecosystem includes various clients with different transport requirements:
- **HTTP-based clients** (like Gemini): use `streamable-http` (default)
- **CLI-based clients**: require `stdio` transport
- **SSE clients**: use `sse` transport

This change allows the same server to work with all these clients by simply setting an environment variable.

## Changes

- `ads_mcp/server.py`: Read transport from `MCP_TRANSPORT` env var, defaulting to `streamable-http`
- `README.md`: Added documentation for transport configuration options

## Test plan

- [x] Verify default behavior unchanged (streamable-http)
- [ ] Test with `MCP_TRANSPORT=stdio`
- [ ] Test with `MCP_TRANSPORT=sse`