### PR TITLE
feat: make transport configurable via TRANSPORT env var

### DIFF
--- a/ads_mcp/server.py
+++ b/ads_mcp/server.py
@@ -49,8 +49,9 @@ def main():
   asyncio.run(update_views_yaml())  # Check and update docs resource
   api.get_ads_client()  # Check Google Ads credentials
   print("mcp server starting...")
+  transport = os.getenv("TRANSPORT", "streamable-http")
   mcp_server.run(
-      transport="streamable-http",
+      transport=transport,
       show_banner=False,
   )  # Initialize and run the server
 


### PR DESCRIPTION
## Problem

The server transport is hardcoded to `streamable-http`, which prevents the server from being used with MCP clients that require **stdio transport** — most notably **Claude Desktop**, which spawns MCP servers as child processes and communicates over stdin/stdout.

Currently, users who want to use this server with Claude Desktop must maintain a local wrapper script that re-imports `mcp_server` and calls `.run(transport="stdio")` manually.

## Solution

Read the transport from a `TRANSPORT` environment variable, defaulting to `streamable-http` so all existing deployments are completely unaffected.

```python
# Before
mcp_server.run(
    transport="streamable-http",
    show_banner=False,
)

# After
transport = os.getenv("TRANSPORT", "streamable-http")
mcp_server.run(
    transport=transport,
    show_banner=False,
)
```

This is consistent with the existing pattern in `server.py` of using `os.getenv()` for runtime configuration (e.g. `USE_GOOGLE_OAUTH_ACCESS_TOKEN`, `FASTMCP_SERVER_BASE_URL`).

## Claude Desktop usage (after this change)

Users can connect directly without any wrapper scripts by adding `"TRANSPORT": "stdio"` to their `claude_desktop_config.json`:

```json
"google-ads-mcp": {
  "command": "uvx",
  "args": [
    "--from",
    "git+https://github.com/google-marketing-solutions/google_ads_mcp.git",
    "run-mcp-server"
  ],
  "env": {
    "GOOGLE_ADS_CREDENTIALS": "/path/to/google-ads.yaml",
    "TRANSPORT": "stdio"
  }
}
```

## Notes

- No behaviour change for existing users (`streamable-http` remains the default)
- No new dependencies
- The `TRANSPORT` naming is intentionally generic — it matches the variable name already used in FastMCP's own documentation and examples