### PR TITLE
fix: handle raw protobuf types in format_value()

### DIFF
--- a/ads_mcp/tools/api.py
+++ b/ads_mcp/tools/api.py
@@ -26,6 +26,8 @@ from google.ads.googleads.util import get_nested_attr
 from google.ads.googleads.v23.services.services.customer_service import CustomerServiceClient
 from google.ads.googleads.v23.services.services.google_ads_service import GoogleAdsServiceClient
 from google.oauth2.credentials import Credentials
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message as ProtobufMessage
 import proto
 import yaml
 
@@ -104,12 +106,19 @@ def format_value(value: Any) -> Any:
   if isinstance(value, proto.marshal.collections.repeated.Repeated):
     return_value = [format_value(i) for i in value]
   elif isinstance(value, proto.Message):
-    # covert to json first to avoid serialization issues
+    # convert to json first to avoid serialization issues
     return_value = proto.Message.to_json(
         value,
         use_integers_for_enums=False,
     )
     return_value = json.loads(return_value)
+  elif isinstance(value, ProtobufMessage):
+    # Handle raw google.protobuf types (e.g. FieldMask from
+    # change_event.changed_fields) that are not proto-plus messages.
+    return_value = MessageToDict(
+        value,
+        preserving_proto_field_name=True,
+    )
   elif isinstance(value, proto.Enum):
     return_value = value.name
   else:


### PR DESCRIPTION
## Summary

- `format_value()` only handles proto-plus messages (`proto.Message`), but some Google Ads API fields return raw `google.protobuf` types instead (e.g., `change_event.changed_fields` is a `google.protobuf.FieldMask`)
- These values fall through to the `else` branch and are returned as non-JSON-serializable Python objects, causing FastMCP's output schema validation to fail silently with "outputSchema defined but no structured output returned"
- Added a branch for `google.protobuf.message.Message` using `MessageToDict()` to properly serialize raw protobuf types

## Reproduction

Query `change_event` with `changed_fields`, `old_resource`, or `new_resource` in the SELECT list via `execute_gaql`. The tool returns "Output validation error: outputSchema defined but no structured output returned" instead of data.

## Test plan

- [x] Verified `change_event.changed_fields` is `google.protobuf.field_mask_pb2.FieldMask` (not `proto.Message`)
- [x] Confirmed `isinstance(FieldMask, proto.Message)` returns `False`
- [x] Tested patched `format_value()` end-to-end: all rows serialize to valid JSON with correct status transitions
- [x] Existing proto-plus and proto.Enum paths unaffected (proto.Message check still comes first)